### PR TITLE
Adding Spring Securty layer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ docker-compose up
 ```
 The application runs on port 8080.
 ### Managing features flags
-The feature flag management console is avaialable at the path `/togglz-console`.
+The feature flag management console is avaialable at the path `/togglz-console`. In order to access it, the user must be authenticated. The credentials are:
+```
+user: admin
+password: secret
+```
+**Warning**: *sharing access credentials is not recommended in production environments at all*.
 ### API Spec
 The only available API is `/time/now`. When the feature flag `NOW_API` is available, it will return a text based representation of the current time. Otherwise, it will return a message indicating that the API is disabled.

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,11 @@
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
@@ -35,6 +40,12 @@
 		<dependency>
 			<groupId>org.togglz</groupId>
 			<artifactId>togglz-spring-boot-starter</artifactId>
+			<version>${togglz.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.togglz</groupId>
+			<artifactId>togglz-spring-security</artifactId>
 			<version>${togglz.version}</version>
 		</dependency>
 

--- a/src/main/java/robert/o/spring/togglz/configuration/SecurityConfiguration.java
+++ b/src/main/java/robert/o/spring/togglz/configuration/SecurityConfiguration.java
@@ -29,6 +29,5 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 // WARNING: plain text secrets should not be used in production.
                 .password("{noop}secret")
                 .roles("ADMIN");
-
     }
 }

--- a/src/main/java/robert/o/spring/togglz/configuration/SecurityConfiguration.java
+++ b/src/main/java/robert/o/spring/togglz/configuration/SecurityConfiguration.java
@@ -1,0 +1,34 @@
+package robert.o.spring.togglz.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Configuration
+public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+
+        http
+                .authorizeRequests()
+                .antMatchers("/togglz-console/**")
+                .authenticated()
+                .and()
+                .formLogin()
+                .and()
+                .logout();
+    }
+
+    @Override
+    public void configure(AuthenticationManagerBuilder auth) throws Exception {
+
+        auth.inMemoryAuthentication()
+                .withUser("admin")
+                // WARNING: plain text secrets should not be used in production.
+                .password("{noop}secret")
+                .roles("ADMIN");
+
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 togglz:
   console:
-    secured: false
+    secured: true
     use-management-port: false
-
+    feature-admin-authority: ROLE_ADMIN
 redis:
   server:
-    host: redis
+    host: localhost

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,4 +5,4 @@ togglz:
     feature-admin-authority: ROLE_ADMIN
 redis:
   server:
-    host: localhost
+    host: redis

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,5 @@
 togglz:
   console:
-    enabled: true
-    path: /togglz-console
     secured: false
     use-management-port: false
 


### PR DESCRIPTION
- Securing Togglz console via Spring Security form login. The credentials are created in memory and are defined in plain text (not recommended for production environments).